### PR TITLE
update path to the 'new' public path on the kindle

### DIFF
--- a/AUTOScript/script.py
+++ b/AUTOScript/script.py
@@ -7,7 +7,7 @@ import pandas as pd
 # One device at a time
 # enable debug mode on the device
 
-device_path = '/storage/emulated/0'
+device_path = '/storage/emulated/0/Documents'
 local_path = './csv_files' 
 current_directory = os.getcwd()
 os.chdir(current_directory)


### PR DESCRIPTION
We needed to change the path that we wrote the CSV files to because Android no longer will let us write to the equivalent of the root of the device. Instead we are now writing to the 'public' path 'Documents'. Updating the data transfer script accordingly.